### PR TITLE
Remove stray equals

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -28,7 +28,7 @@ This document details the internal design of the `jinni` MCP Server, `jinni` CLI
 *   **Output Formatting:**
     *   Concatenates file content.
     *   Prepends a path header (e.g., ````path=src/app.py`) for each file unless `list_only` is true. Content is enclosed in triple backticks.
-    *   Uses consistent separators (`========`) between file entries when not `list_only`. (This separator is still used by `core_logic.py` to join file blocks from `file_processor.py`)
+    *   When not `list_only`, file entries are separated by a blank line.
 *   **Large Context Handling:**
     *   Implement a configurable total content size limit (default: 100MB, configurable via `JINNI_MAX_SIZE_MB` env var). Accumulate file sizes during traversal. If the limit is exceeded, **abort** processing and return/print an explanatory error message (e.g., "Error: Total content size exceeds limit of 100MB").
 

--- a/jinni/core_logic.py
+++ b/jinni/core_logic.py
@@ -42,7 +42,7 @@ if not logger.handlers and not logging.getLogger().handlers:
 # --- Constants ---
 DEFAULT_SIZE_LIMIT_MB = 100
 ENV_VAR_SIZE_LIMIT = 'JINNI_MAX_SIZE_MB'
-SEPARATOR = "\n\n" + "=" * 80 + "\n"
+SEPARATOR = "\n\n"
 
 # --- Main Processing Function ---
 def read_context(

--- a/jinni/file_processor.py
+++ b/jinni/file_processor.py
@@ -16,7 +16,6 @@ if not logger.handlers and not logging.getLogger().handlers:
      logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # Constants might be moved to a central place later
-SEPARATOR = "\n\n" + "=" * 80 + "\n"
 
 def process_file(
     file_path: Path,


### PR DESCRIPTION
## Summary
- update design notes about blank line separation
- simplify file separator constant in `core_logic`
- remove unused separator constant from `file_processor`

## Testing
- `python -m unittest discover tests` *(fails: ModuleNotFoundError: No module named 'pytest')*