### PR TITLE
Handle .gitignore during context gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic fallback for WSL path translation on Windows when `wslpath` is unavailable. Jinni now attempts to determine the default distro using `wsl -l -q` and constructs the UNC path (`\\wsl$\...`) manually.
 - Environment variable `JINNI_ASSUME_WSL_DISTRO` allows overriding the automatically detected default distro for the manual fallback.
 - Added support for stripping `vscode-remote://wsl.localhost/Distro/...` URIs to `/...` on non-Windows platforms.
+- Context gathering now respects `.gitignore` files (lower priority than `.contextfiles`).
 
 ### Changed
 - If you install WSL while Jinni is running, restart Jinni to pick up the new `wslpath`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ These tools are opinionated about what counts as relevant project context to bes
     * Dotfiles and hidden directories
     * Common naming conventions for logs, build directories, tempfiles, etc
 
-Inclusions/exclusions are customizable with complete granularity if required using .contextfiles - this works like .gitignore except defining inclusions.
+Inclusions/exclusions are customizable with complete granularity if required using `.contextfiles` – this works like `.gitignore` except defining inclusions. `.gitignore` files themselves are also respected automatically, but any rules in `.contextfiles` take priority.
 
 The MCP server can provide as much or as little of the project as desired. By default the scope is the whole project, but the model can ask for specific modules / matching patterns / etc.
 
@@ -73,6 +73,7 @@ Cursor can silently drop context that is larger than the allowed maximum, so if 
 *   **Efficient Context Gathering:** Reads and concatenates relevant project files in one operation.
 *   **Intelligent Filtering (Gitignore-Style Inclusion):**
     *   Uses a system based on `.gitignore` syntax (`pathspec` library's `gitwildmatch`).
+    *   Automatically loads `.gitignore` files from the project root downward. These exclusions can be overridden by rules in `.contextfiles`.
     *   Supports hierarchical configuration using `.contextfiles` placed within your project directories. Rules are applied dynamically based on the file/directory being processed.
     *   **Matching Behavior:** Patterns match against the path relative to the **target directory** being processed (or the project root if no specific target is given). For example, if targeting `src/`, a rule `!app.py` in `src/.contextfiles` will match `app.py`. Output paths remain relative to the original project root.
     *   **Overrides:** Supports `--overrides` (CLI) or `rules` (MCP) to use a specific set of rules exclusively. When overrides are active, both built-in default rules and any `.contextfiles` are ignored. Path matching for overrides is still relative to the target directory.
@@ -241,8 +242,8 @@ Jinni uses `.contextfiles` (or an override file) to determine which files and di
     1.  **Determine Target:** Jinni identifies the target directory (either explicitly provided or the project root).
     2.  **Override Check:** If `--overrides` (CLI) or `rules` (MCP) are provided, these rules are used exclusively. All `.contextfiles` and built-in defaults are ignored. Path matching is relative to the target directory.
     3.  **Dynamic Context Rules (No Overrides):** When processing a file or subdirectory within the target directory:
-        *   Jinni finds all `.contextfiles` starting from the target directory down to the current item's directory.
-        *   It combines the rules from these discovered `.contextfiles` with the built-in default rules.
+        *   Jinni finds all `.gitignore` and `.contextfiles` starting from the target directory down to the current item's directory.
+        *   Rules from `.gitignore` are applied first, then built-in defaults, and finally any `.contextfiles` (which take precedence).
         *   It compiles these combined rules into a specification (`PathSpec`).
         *   It matches the current file/subdirectory path, calculated *relative to the target directory*, against this specification.
     4.  **Matching:** The **last pattern** in the combined rule set that matches the item's relative path determines its fate. `!` negates the match. If no user-defined pattern matches, the item is included unless it matches a built-in default exclusion (like `!.*`).

--- a/jinni-server-pkg/pyproject.toml
+++ b/jinni-server-pkg/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jinni-server"
-version = "0.2.6" # Match the main jinni package version
+version = "0.2.7" # Match the main jinni package version
 description = "Server component for Jinni (enables 'uvx jinni-server')."
 readme = "README.md" # Optional: Create a simple README for this package
 requires-python = ">=3.10" # Match the main jinni package requirement
@@ -25,7 +25,7 @@ classifiers = [
 ]
 # This package depends on the main 'jinni' package
 dependencies = [
-    "jinni==0.2.6" # Pin to the exact main package version
+    "jinni==0.2.7" # Pin to the exact main package version
 ]
 
 [project.urls]

--- a/jinni/utils.py
+++ b/jinni/utils.py
@@ -30,6 +30,7 @@ from .config_system import (
     compile_spec_from_rules, # Needed by get_large_files
     DEFAULT_RULES,           # Needed by get_large_files
     CONTEXT_FILENAME,        # Needed by _find_context_files_for_dir
+    GITIGNORE_FILENAME,      # Needed by _find_gitignore_files_for_dir
 )
 
 # Setup logger for this module
@@ -497,6 +498,35 @@ def _find_context_files_for_dir(dir_path: Path, root_path: Path) -> List[Path]:
             logger.debug(f"Found context file: {context_file}")
 
     return context_files
+
+def _find_gitignore_files_for_dir(dir_path: Path, root_path: Path) -> List[Path]:
+    """Finds all .gitignore files from root_path down to dir_path."""
+    gitignore_files = []
+    current = dir_path.resolve()
+    root = root_path.resolve()
+
+    if not (current == root or root in current.parents):
+         logger.warning(f"Directory {current} is not within the root {root}. Cannot find gitignore files.")
+         return []
+
+    paths_to_check = []
+    temp_path = current
+    while temp_path >= root:
+        paths_to_check.append(temp_path)
+        if temp_path == root:
+            break
+        parent = temp_path.parent
+        if parent == temp_path:
+            break
+        temp_path = parent
+
+    for p in reversed(paths_to_check):
+        ignore_file = p / GITIGNORE_FILENAME
+        if ignore_file.is_file():
+            gitignore_files.append(ignore_file)
+            logger.debug(f"Found gitignore file: {ignore_file}")
+
+    return gitignore_files
 
 # --- WSL Path Translation Helper ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jinni"
-version = "0.2.6"
+version = "0.2.7"
 description = "A tool to help LLMs efficiently read and understand project context."
 readme = "README.md"
 requires-python = ">=3.10" # Minimum Python version required by dependencies (e.g., mcp)

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -138,9 +138,9 @@ def test_cli_debug_explain(test_environment: Path):
     # Check stderr for expected explanation patterns (may need adjustment based on exact logging)
     # Look for dynamic spec source descriptions
     assert "DEBUG:jinni.context_walker:Compiled spec for" in stderr # Check for log from context_walker
-    assert "from Context files at root" in stderr # Root context (Updated assertion)
-    assert "from Context files up to ./src" in stderr # Src context
-    assert "from Context files up to ./dir_a" in stderr # Dir_a context
+    assert "from Gitignore+context files at root" in stderr  # Root context
+    assert "from Gitignore+context files up to ./src" in stderr  # Src context
+    assert "from Gitignore+context files up to ./dir_a" in stderr  # Dir_a context
 
     # Check specific inclusion/exclusion reasons based on the dynamic context
     # Check for the log message from the context walker module
@@ -149,12 +149,12 @@ def test_cli_debug_explain(test_environment: Path):
     assert "DEBUG:jinni.context_walker:Pruning Directory" in stderr # Check context_walker logger
 
     # Example specific checks (adapt based on actual log output)
-    assert "Including File: " in stderr and "file_root.txt" in stderr and "Context files at root" in stderr # Corrected assertion
-    assert "Excluding File: " in stderr and "root.log" in stderr and "Context files at root" in stderr # Excluded by root !*.log (Corrected assertion)
-    assert "Including File: " in stderr and "src/app.py" in stderr and "Context files up to ./src" in stderr # Included by root src/
-    assert "Excluding File: " in stderr and "dir_a/file_a1.txt" in stderr and "Context files up to ./dir_a" in stderr # Excluded by dir_a !file_a1.txt
-    assert "Including File: " in stderr and "dir_a/important.log" in stderr and "Context files up to ./dir_a" in stderr # Included by dir_a important.log
-    assert "Keeping Directory: " in stderr and "dir_b" in stderr and "Context files at root" in stderr # Kept because included by default '*' at root (Corrected assertion)
+    assert "Including File: " in stderr and "file_root.txt" in stderr and "Gitignore+context files at root" in stderr
+    assert "Excluding File: " in stderr and "root.log" in stderr and "Gitignore+context files at root" in stderr
+    assert "Including File: " in stderr and "src/app.py" in stderr and "Gitignore+context files up to ./src" in stderr
+    assert "Excluding File: " in stderr and "dir_a/file_a1.txt" in stderr and "Gitignore+context files up to ./dir_a" in stderr
+    assert "Including File: " in stderr and "dir_a/important.log" in stderr and "Gitignore+context files up to ./dir_a" in stderr
+    assert "Keeping Directory: " in stderr and "dir_b" in stderr and "Gitignore+context files at root" in stderr
 
     # Check stdout is still correct (same as test_cli_with_contextfiles)
     assert "```path=file_root.txt" in stdout

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -363,6 +363,19 @@ def test_find_context_files_helper(test_dir: Path):
     files = _find_context_files_for_dir(root.parent, root)
     assert files == []
 
+def test_gitignore_respected_and_overridden(test_dir: Path):
+    """Ensure .gitignore excludes files unless overridden by .contextfiles."""
+    (test_dir / ".gitignore").write_text("lib/\n", encoding="utf-8")
+
+    # Without context override, lib/ should be excluded
+    content = run_read_context_helper("project", test_dir.parent)
+    assert "```path=lib/somelib.py" not in content
+
+    # Add context file that re-includes lib/
+    (test_dir / CONTEXT_FILENAME).write_text("lib/\n", encoding="utf-8")
+    content = run_read_context_helper("project", test_dir.parent)
+    assert "```path=lib/somelib.py" in content
+
 # Test removed as project_root is now mandatory
 # def test_read_context_project_root_default(test_dir: Path):
 


### PR DESCRIPTION
## Summary
- incorporate gitignore rules when computing the active PathSpec
- load gitignore rules with lower priority than `.contextfiles`
- add helper for finding gitignore files
- update debug logging expectations for gitignore support
- test new gitignore behaviour
- document gitignore usage
- bump package versions

## Testing
- `pytest -q`