### PR TITLE
Improve gitignore handling

### DIFF
--- a/jinni/config_system.py
+++ b/jinni/config_system.py
@@ -93,15 +93,18 @@ def load_gitignore_as_context_rules(file_path: Path) -> List[str]:
     raw_lines = load_rules_from_file(file_path)
     converted: List[str] = []
     for line in raw_lines:
-        stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
+        # Preserve leading/trailing spaces (except final newline) to mimic
+        # gitignore semantics. Comments only apply when the very first
+        # character is '#'.
+        line_no_nl = line.rstrip("\n")
+        if line_no_nl == "" or line_no_nl.startswith("#"):
             continue
-        if stripped.startswith('!'):
+        if line_no_nl.startswith("!"):
             # Git's negation means include; keep without '!'
-            converted.append(stripped[1:])
+            converted.append(line_no_nl[1:])
         else:
             # Regular gitignore entry is an exclusion -> prefix '!'
-            converted.append('!' + stripped)
+            converted.append("!" + line_no_nl)
     return converted
 
 def compile_spec_from_rules(rules: Iterable[str], source_description: str = "rules list") -> pathspec.PathSpec:

--- a/tests/test_config_system.py
+++ b/tests/test_config_system.py
@@ -8,8 +8,9 @@ import pathspec # Direct import, assume it's installed
 from jinni.config_system import (
     load_rules_from_file,
     compile_spec_from_rules,
-    DEFAULT_RULES, # Import to potentially check its content or use in tests
-    CONTEXT_FILENAME
+    load_gitignore_as_context_rules,
+    DEFAULT_RULES,  # Import to potentially check its content or use in tests
+    CONTEXT_FILENAME,
 )
 
 # --- Tests for load_rules_from_file ---
@@ -127,6 +128,36 @@ def test_default_rules_compilation():
     assert not spec.match_file("__pycache__/some.cpython-39.pyc")
     # Check something not excluded by default
     assert spec.match_file("src/main.py") # Defaults include '*' first, so this should be included
+
+# --- New tests for .gitignore parsing ---
+
+def test_load_gitignore_as_context_rules_spaces_and_comments(tmp_path: Path):
+    """Ensure gitignore lines are converted with spaces preserved and comments ignored."""
+    gi_file = tmp_path / ".gitignore"
+    gi_file.write_text(
+        "\n".join(
+            [
+                "# a comment",
+                "foo.py",
+                "!bar.py",
+                " baz.txt",
+                "trail.txt   ",
+                "\\#literal",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    rules = load_gitignore_as_context_rules(gi_file)
+
+    assert rules == [
+        "!foo.py",
+        "bar.py",
+        "! baz.txt",
+        "!trail.txt   ",
+        "!\\#literal",
+    ]
 
 # --- Remove tests for check_item and find_and_compile_contextfile ---
 # All tests below this line from the original file are removed.


### PR DESCRIPTION
## Summary
- preserve spaces when parsing `.gitignore` rules
- test `.gitignore` parsing with spaces and comments

## Testing
- `pytest -q`